### PR TITLE
feat: add altitude to location point options

### DIFF
--- a/src/LocationEditor.tsx
+++ b/src/LocationEditor.tsx
@@ -5,7 +5,7 @@ import { Location } from './types';
 
 export const LocationEditor: React.FC<StandardEditorProps<Location[]>> = ({ value, onChange }) => {
   const addLocation = () => {
-    const newLocations = [...value, { name: 'Unnamed', longitude: 0.0, latitude: 0.0 }];
+    const newLocations = [...value, { name: 'Unnamed', longitude: 0.0, latitude: 0.0, altitude: 0.0}];
     onChange(newLocations);
   };
 
@@ -37,6 +37,11 @@ export const LocationEditor: React.FC<StandardEditorProps<Location[]>> = ({ valu
             type="number"
             value={location.latitude}
             onChange={(e) => updateLocation(index, { ...location, latitude: +e.target.value })}
+          />
+          <input
+            type="number"
+            value={location.altitude}
+            onChange={(e) => updateLocation(index, { ...location, altitude: +e.target.value })}
           />
           <button onClick={() => deletePoint(index)}>Delete</button>
         </div>

--- a/src/components/SatelliteVisualizer.tsx
+++ b/src/components/SatelliteVisualizer.tsx
@@ -248,7 +248,7 @@ export const SatelliteVisualizer: React.FC<Props> = ({ options, data, timeRange,
         {options.locations.map((location, index) => (
           <Entity
             name={location.name}
-            position={Cartesian3.fromDegrees(location.longitude, location.latitude, 0.0)}
+            position={Cartesian3.fromDegrees(location.longitude, location.latitude, location.altitude)}
             key={index}
           >
             <PointGraphics

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,4 +41,5 @@ export interface Location {
   name: string;
   longitude: number;
   latitude: number;
+  altitude: number;
 }


### PR DESCRIPTION
Heyo, this is a simple change that just captures an Altitude parameter along with Lon/Lat. When no altitude is specified, it defaults to 0.

Let me know if I missed updating something. I'm a javascript/frontend n00b. 

<img width="1512" alt="Screenshot 2024-01-25 at 10 08 11 AM" src="https://github.com/lucas-bremond/satellite-visualizer/assets/16886766/de5b9ccc-93cb-4acf-adc3-d7816f3c2271">

