### PR TITLE
Replace Variables in URI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satellite-visualizer",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satellite-visualizer",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satellite-visualizer",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "3D satellite visualization panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/SatelliteVisualizer.tsx
+++ b/src/components/SatelliteVisualizer.tsx
@@ -53,7 +53,15 @@ const getStyles = () => {
   };
 };
 
-export const SatelliteVisualizer: React.FC<Props> = ({ options, data, timeRange, width, height, eventBus, replaceVariables }) => {
+export const SatelliteVisualizer: React.FC<Props> = ({
+  options,
+  data,
+  timeRange,
+  width,
+  height,
+  eventBus,
+  replaceVariables,
+}) => {
   Ion.defaultAccessToken = options.accessToken;
 
   const styles = useStyles2(getStyles);

--- a/src/components/SatelliteVisualizer.tsx
+++ b/src/components/SatelliteVisualizer.tsx
@@ -53,7 +53,7 @@ const getStyles = () => {
   };
 };
 
-export const SatelliteVisualizer: React.FC<Props> = ({ options, data, timeRange, width, height, eventBus }) => {
+export const SatelliteVisualizer: React.FC<Props> = ({ options, data, timeRange, width, height, eventBus, replaceVariables }) => {
   Ion.defaultAccessToken = options.accessToken;
 
   const styles = useStyles2(getStyles);
@@ -186,12 +186,11 @@ export const SatelliteVisualizer: React.FC<Props> = ({ options, data, timeRange,
           throw new Error(`Error loading Ion Resource of Model: [${error}].`);
         });
     } else if (options.modelAssetUri) {
-      setSatelliteResource(options.modelAssetUri);
+      setSatelliteResource(replaceVariables(options.modelAssetUri));
     } else {
       setSatelliteResource(undefined);
     }
-  }, [options.modelAssetId, options.modelAssetUri, options.accessToken]);
-
+  }, [options.modelAssetId, options.modelAssetUri, options.accessToken, replaceVariables]);
   useEffect(() => setViewerKey((prevKey) => prevKey + 1), [options]);
 
   useEffect(() => {

--- a/src/components/__tests__/SatelliteVisualizer.replaceVariables.test.tsx
+++ b/src/components/__tests__/SatelliteVisualizer.replaceVariables.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+// Resium is mocked to avoid WebGL/DOM dependencies.
+jest.mock('resium', () => ({
+  Viewer: () => null,
+  Clock: () => null,
+  Entity: () => null,
+  PointGraphics: () => null,
+  ModelGraphics: () => null,
+  PathGraphics: () => null,
+  LabelGraphics: () => null,
+}));
+
+import { SatelliteVisualizer } from '../SatelliteVisualizer';
+
+const baseProps = {
+  // locations must be an array or the component will crash on .map()
+  options: { locations: [] } as any,
+  data: { series: [] } as any,
+  timeRange: { from: { toDate: () => new Date(0) }, to: { toDate: () => new Date(0) } } as any,
+  replaceVariables: jest.fn((str: string) => str),
+} as any;
+
+describe('SatelliteVisualizer: replaceVariables', () => {
+  const replaceVariables = jest.fn((str: string) =>
+    str.replace(`\${Example_Satellite_Name}`,"my-satellite")
+  );
+
+  beforeEach(() => replaceVariables.mockClear());
+
+  it('leaves the URI unchanged when it contains no variables', () => {
+    const plainUrl = `https://example.com/my-satellite.glb`;
+
+    render(
+      <SatelliteVisualizer
+        {...baseProps}
+        options={{ ...baseProps.options, modelAssetUri: plainUrl }}
+        replaceVariables={replaceVariables}
+      />
+    );
+
+    expect(replaceVariables).toHaveBeenCalledWith(plainUrl);
+    expect(replaceVariables).toHaveReturnedWith(plainUrl);
+  });
+
+  it('replaces the variable in the URI', () => {
+    const templateUrl = `https://example.com/\${Example_Satellite_Name}.glb`;
+    const resolvedUrl = `https://example.com/my-satellite.glb`;
+
+    render(
+      <SatelliteVisualizer
+        {...baseProps}
+        options={{ ...baseProps.options, modelAssetUri: templateUrl }}
+        replaceVariables={replaceVariables}
+      />
+    );
+
+    expect(replaceVariables).toHaveBeenCalledWith(templateUrl);
+    expect(replaceVariables).toHaveReturnedWith(resolvedUrl);
+  });
+});
+

--- a/src/components/__tests__/SatelliteVisualizer.replaceVariables.test.tsx
+++ b/src/components/__tests__/SatelliteVisualizer.replaceVariables.test.tsx
@@ -23,9 +23,7 @@ const baseProps = {
 } as any;
 
 describe('SatelliteVisualizer: replaceVariables', () => {
-  const replaceVariables = jest.fn((str: string) =>
-    str.replace(`\${Example_Satellite_Name}`,"my-satellite")
-  );
+  const replaceVariables = jest.fn((str: string) => str.replace(`\${Example_Satellite_Name}`, 'my-satellite'));
 
   beforeEach(() => replaceVariables.mockClear());
 
@@ -60,4 +58,3 @@ describe('SatelliteVisualizer: replaceVariables', () => {
     expect(replaceVariables).toHaveReturnedWith(resolvedUrl);
   });
 });
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./.config/tsconfig.json"
+  "extends": "./.config/tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
 }


### PR DESCRIPTION
Hi, really cool plugin!

I want to be able to use grafana variables in the asset URI. grafana apparently has a [replaceVariables](https://www.bookstack.cn/read/Grafana-8.5-en/ca60071fd273b286.md function), that does this.

To make sure things don't break I added a minimal test with some mocks.

Please let me know if you have any opinions.