### PR TITLE
update CI workflow to use latest action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -43,20 +43,20 @@ jobs:
 
       - name: Setup Go environment
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: '1.21'
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v2
+        uses: magefile/mage-action@v4
         with:
           version: latest
           args: coverage
 
       - name: Build backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v2
+        uses: magefile/mage-action@v4
         with:
           version: latest
           args: buildAll
@@ -82,7 +82,7 @@ jobs:
         run: docker compose down
 
       - name: Archive E2E output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: steps.check-for-e2e.outputs.has-e2e == 'true' && steps.run-e2e-tests.outcome != 'success'
         with:
           name: cypress-videos

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,6 @@ process.env.TZ = 'UTC';
 module.exports = {
   // Jest configuration provided by Grafana scaffolding
   ...require('./.config/jest.config'),
+  // CESIUM_BASE_URL is normally injected by webpack at build time
+  globals: { CESIUM_BASE_URL: '' },
 };


### PR DESCRIPTION
The [previous build failed](https://github.com/lucas-bremond/satellite-visualizer/actions/runs/24508509287/job/71729699064), because the [gh action was deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

I noticed a bunch of other tools also have been deprecated, so I decided to update them too.